### PR TITLE
docs: claude-slack-to-notion 레포 이관 링크 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ AI 도구를 활용한 개발 흐름을 실험하며,
 
 - [claude-devex](https://github.com/idean3885/claude-devex) — AI 기반 개발 사이클 자동화 도구
 - [claude-cross-verify](https://github.com/idean3885/claude-cross-verify) — 의사결정·설계·문서·구현 4축 교차 검증 에이전트
-- [claude-slack-to-notion](https://github.com/dykim-base-project/claude-slack-to-notion) — Slack 스레드를 Notion으로 정리하는 MCP 플러그인
+- [claude-slack-to-notion](https://github.com/idean3885/claude-slack-to-notion) — Slack 스레드를 Notion으로 정리하는 MCP 플러그인
 
 ### Blog
 


### PR DESCRIPTION
## Summary
- claude-slack-to-notion 링크를 dykim-base-project → idean3885로 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)