### PR TITLE
fix: 소개 N년차 제거 및 Tech Stack 수정 (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## 백엔드 개발자
 
-2019년부터 백엔드 개발을 해온 7년차 개발자입니다.
+2019년부터 백엔드 개발을 해온 개발자입니다.
 Kubernetes 기반 멀티 테넌시 서비스를 설계·운영하며,
 앱·GPU 클라우드 환경에서 인프라와 서비스를 함께 다루고 있습니다.
 
@@ -13,7 +13,7 @@ AI 도구를 활용한 개발 흐름을 실험하며,
 ![Spring Boot](https://img.shields.io/badge/Spring_Boot-6DB33F?style=flat-square&logo=springboot&logoColor=white)
 ![Kubernetes](https://img.shields.io/badge/Kubernetes-326CE5?style=flat-square&logo=kubernetes&logoColor=white)
 ![Helm](https://img.shields.io/badge/Helm-0F1689?style=flat-square&logo=helm&logoColor=white)
-![ArgoCD](https://img.shields.io/badge/Argo_CD-EF7B4D?style=flat-square&logo=argo&logoColor=white)
+![MySQL](https://img.shields.io/badge/MySQL-4479A1?style=flat-square&logo=mysql&logoColor=white)
 
 ### Projects
 


### PR DESCRIPTION
## 작업 내용
- "7년차" 표현 제거, "2019년부터"만으로 경력 연차 전달
- ArgoCD 뱃지 제거, MySQL 뱃지 추가

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ⬜ 해당없음 | 마크다운 변경만 |
| 테스트 | ⬜ 해당없음 | 마크다운 변경만 |
| 문서 동기화 | ✅ 완료 | 블로그 소개와 동기화 |

Closes #14