### PR TITLE
chore: 블로그 URL blog.idean.me 일괄 교체 (#16)

### DIFF
--- a/CONTENT_ARCHITECTURE.md
+++ b/CONTENT_ARCHITECTURE.md
@@ -15,8 +15,8 @@
 | 표면 | 위치 | 역할 | 대상 |
 |------|------|------|------|
 | **GitHub Profile README** | [idean3885/idean3885](https://github.com/idean3885/idean3885) | 허브 — 30초 요약, 진입점 | GitHub 방문자 |
-| **Blog Repo About** | idean3885.github.io repo settings | 메타데이터 — 검색/탐색 노출 | GitHub 검색 |
-| **Blog About (홈 소개 섹션)** | [홈 페이지 소개 영역](https://idean3885.github.io) | 깊이 — 자기소개, 포커스 영역 안내 | 블로그 방문자 |
+| **Blog Repo About** | blog.idean.me repo settings | 메타데이터 — 검색/탐색 노출 | GitHub 검색 |
+| **Blog About (홈 소개 섹션)** | [홈 페이지 소개 영역](https://blog.idean.me) | 깊이 — 자기소개, 포커스 영역 안내 | 블로그 방문자 |
 
 ## 정보 흐름 (Information Flow)
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ AI 도구를 활용한 개발 흐름을 실험하며,
 
 ### Blog
 
-[idean3885.github.io](https://idean3885.github.io)
+[blog.idean.me](https://blog.idean.me)
 
-- [AI에게 코드를 맡기고 나서 달라진 일하는 방식](https://idean3885.github.io/posts/ai-changed-my-workflow/)
-- [코드에서 사고로 — AI 시대, 개발자의 역할 재정의](https://idean3885.github.io/posts/from-coding-to-thinking/)
-- [AI 협업에서의 교차 검증 — 속도가 아닌 판단을 자동화하기](https://idean3885.github.io/posts/cross-verification-in-ai-collaboration/)
-- [미터링 배치를 만들고 나서야 알게 된 것들 — 배치 전략과 패턴에 이름 붙이기](https://idean3885.github.io/posts/batch-patterns-naming/)
+- [AI에게 코드를 맡기고 나서 달라진 일하는 방식](https://blog.idean.me/posts/ai-changed-my-workflow/)
+- [코드에서 사고로 — AI 시대, 개발자의 역할 재정의](https://blog.idean.me/posts/from-coding-to-thinking/)
+- [AI 협업에서의 교차 검증 — 속도가 아닌 판단을 자동화하기](https://blog.idean.me/posts/cross-verification-in-ai-collaboration/)
+- [미터링 배치를 만들고 나서야 알게 된 것들 — 배치 전략과 패턴에 이름 붙이기](https://blog.idean.me/posts/batch-patterns-naming/)


### PR DESCRIPTION
## 작업 내용
- idean3885.github.io → blog.idean.me 일괄 교체
- README.md, CONTENT_ARCHITECTURE.md

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ⬜ 해당없음 | URL 텍스트 변경만 |
| 테스트 | ⬜ 해당없음 | URL 텍스트 변경만 |
| 문서 동기화 | ✅ 완료 | 블로그 도메인 통일 |

Closes #16