### PR TITLE
docs: Profile Projects에 trip-planner 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ AI 도구를 활용한 개발 흐름을 실험하며,
 
 ### Projects
 
-- [claude-devex](https://github.com/idean3885/claude-devex) - AI 기반 개발 사이클 자동화 도구
-- [claude-cross-verify](https://github.com/idean3885/claude-cross-verify) - 의사결정·설계·문서·구현 4축 교차 검증 에이전트
+- [trip-planner](https://github.com/idean3885/trip-planner) - spec-kit 풀사이클 + 하네스를 1인 개발에 적용한 AI 협업 방법론 테스트베드 ([서비스](https://trip.idean.me))
+- [claude-cross-verify](https://github.com/idean3885/claude-cross-verify) - 의사결정, 설계, 문서, 구현 4축 교차 검증 에이전트
 - [claude-slack-to-notion](https://github.com/idean3885/claude-slack-to-notion) - Slack 스레드를 Notion으로 정리하는 MCP 플러그인
+- [claude-devex](https://github.com/idean3885/claude-devex) - AI 기반 개발 사이클 자동화 도구
 
 ### Blog
 


### PR DESCRIPTION
## Summary

- trip-planner를 Projects 최상단에 추가 (AI 협업 방법론 테스트베드 프레이밍)
- cross-verify 설명의 가운뎃점을 콤마로 교체 (문서 스타일 규칙)
- devex는 하단으로 재배치 (포트폴리오/이력서에서는 교차 검증 본문으로 흡수된 발자취)

## Test plan

- [x] 로컬 Edit 검증
- [ ] 머지 후 github.com/idean3885 허브 반영 확인

Closes #20