### PR TITLE
docs: trip-planner 설명 보강 및 cross-verify 스타일 정합

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ AI 도구를 활용한 개발 흐름을 실험하며,
 
 ### Projects
 
-- [trip-planner](https://github.com/idean3885/trip-planner) - 우리의 여행 앱 만들기 — React + GitHub Pages 모바일 웹
+- [trip-planner](https://github.com/idean3885/trip-planner) - 우리의 여행. spec-kit 풀사이클과 하네스를 1인 개발에 적용한 AI 협업 방법론 테스트베드 ([서비스](https://trip.idean.me))
 - [claude-devex](https://github.com/idean3885/claude-devex) - AI 기반 개발 사이클 자동화 도구
-- [claude-cross-verify](https://github.com/idean3885/claude-cross-verify) - 의사결정·설계·문서·구현 4축 교차 검증 에이전트
+- [claude-cross-verify](https://github.com/idean3885/claude-cross-verify) - 의사결정, 설계, 문서, 구현 4축 교차 검증 에이전트
 - [claude-slack-to-notion](https://github.com/idean3885/claude-slack-to-notion) - Slack 스레드를 Notion으로 정리하는 MCP 플러그인
 
 ### Blog


### PR DESCRIPTION
## Summary

- trip-planner 설명을 \"AI 협업 방법론 테스트베드\"로 보강 (포트폴리오 ADR-012 정합)
- cross-verify 가운뎃점을 콤마로 교체 (문서 스타일 규칙)

## Test plan

- [x] 로컬 diff 확인
- [ ] 머지 후 github.com/idean3885 허브 반영 확인

Closes #20