### PR TITLE
docs: README 기술 스택 뱃지를 소제목 아래 줄로 재배치

### DIFF
--- a/CONTENT_ARCHITECTURE.md
+++ b/CONTENT_ARCHITECTURE.md
@@ -96,11 +96,11 @@ Blog Repo About (메타데이터)
 - 본업(백엔드) 외 부수 위치로 노출하고 섹션 제목·부제("백엔드 본업 외…")로 가중치를 명시 (면접관이 본업과 혼동하지 않도록)
 - 운영 중인 자산만 노출한다. trip-planner는 live 서비스(trip.idean.me, 풀스택 포트폴리오)로 전환되어 "결과 미완성" 제외 근거가 해소됨 → 개인 프로젝트에 편입
 
-## 현황 (Last Updated: 2026-07-03)
+## 현황 (Last Updated: 2026-07-09)
 
 | 표면 | 상태 | 미완료 항목 |
 |------|------|-------------|
-| GitHub Profile README | 개인 프로젝트 재편(cross-verify 제거·trip-planner 추가) + 주요 글 3개 + Tech Stack 이력서 정합 | - |
+| GitHub Profile README | 개인 프로젝트 재편(cross-verify 제거·trip-planner 추가) + 주요 글 3개 + Tech Stack 이력서 정합 + 기술 스택 뱃지를 소제목 아래 줄로 재배치(#42, 레이아웃) | - |
 | Blog Repo About | 완료 | - |
 | Blog About (홈 소개 섹션) | 주요 글 3개 평탄화(교차 검증 카드 제거) | - |
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,17 @@ Kubernetes 기반 PaaS, GPU 멀티테넌시 서비스, 시계열 데이터 파�
 
 ### 기술 스택
 
-**Backend** ![Java](https://img.shields.io/badge/Java-007396?style=flat-square&logo=openjdk&logoColor=white) ![Spring Boot](https://img.shields.io/badge/Spring_Boot-6DB33F?style=flat-square&logo=springboot&logoColor=white) ![JPA](https://img.shields.io/badge/JPA-59666C?style=flat-square&logo=hibernate&logoColor=white)
+**Backend**  
+![Java](https://img.shields.io/badge/Java-007396?style=flat-square&logo=openjdk&logoColor=white) ![Spring Boot](https://img.shields.io/badge/Spring_Boot-6DB33F?style=flat-square&logo=springboot&logoColor=white) ![JPA](https://img.shields.io/badge/JPA-59666C?style=flat-square&logo=hibernate&logoColor=white)
 
-**Infra / DevOps** ![Kubernetes](https://img.shields.io/badge/Kubernetes-326CE5?style=flat-square&logo=kubernetes&logoColor=white) ![Helm](https://img.shields.io/badge/Helm-0F1689?style=flat-square&logo=helm&logoColor=white) ![ArgoCD](https://img.shields.io/badge/ArgoCD-EF7B4D?style=flat-square&logo=argo&logoColor=white) ![Jenkins](https://img.shields.io/badge/Jenkins-D24939?style=flat-square&logo=jenkins&logoColor=white) ![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-2088FF?style=flat-square&logo=githubactions&logoColor=white) ![Prometheus](https://img.shields.io/badge/Prometheus-E6522C?style=flat-square&logo=prometheus&logoColor=white)
+**Infra / DevOps**  
+![Kubernetes](https://img.shields.io/badge/Kubernetes-326CE5?style=flat-square&logo=kubernetes&logoColor=white) ![Helm](https://img.shields.io/badge/Helm-0F1689?style=flat-square&logo=helm&logoColor=white) ![ArgoCD](https://img.shields.io/badge/ArgoCD-EF7B4D?style=flat-square&logo=argo&logoColor=white) ![Jenkins](https://img.shields.io/badge/Jenkins-D24939?style=flat-square&logo=jenkins&logoColor=white) ![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-2088FF?style=flat-square&logo=githubactions&logoColor=white) ![Prometheus](https://img.shields.io/badge/Prometheus-E6522C?style=flat-square&logo=prometheus&logoColor=white)
 
-**Data** ![MySQL](https://img.shields.io/badge/MySQL-4479A1?style=flat-square&logo=mysql&logoColor=white) ![Redis](https://img.shields.io/badge/Redis-DC382D?style=flat-square&logo=redis&logoColor=white)
+**Data**  
+![MySQL](https://img.shields.io/badge/MySQL-4479A1?style=flat-square&logo=mysql&logoColor=white) ![Redis](https://img.shields.io/badge/Redis-DC382D?style=flat-square&logo=redis&logoColor=white)
 
-**AI** ![Claude Code](https://img.shields.io/badge/Claude_Code-D97757?style=flat-square&logo=claude&logoColor=white) ![MCP](https://img.shields.io/badge/MCP-000000?style=flat-square&logo=modelcontextprotocol&logoColor=white)
+**AI**  
+![Claude Code](https://img.shields.io/badge/Claude_Code-D97757?style=flat-square&logo=claude&logoColor=white) ![MCP](https://img.shields.io/badge/MCP-000000?style=flat-square&logo=modelcontextprotocol&logoColor=white)
 
 ### 주요 글
 


### PR DESCRIPTION
## 작업 내용

README 기술 스택 뱃지를 카테고리 라벨 아래 줄로 재배치. 순수 레이아웃 변경(항목·사상 무변경). 청사진 현황 표 반영.

## 변경 사항

- README 기술 스택 4개 카테고리 뱃지를 소제목 아래 줄로 이동 (하드 라인브레이크)
- CONTENT_ARCHITECTURE.md 현황 표 갱신 + Last Updated 2026-07-09

## 자가 검증

| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ⬜ 해당없음 | 문서 변경 |
| 테스트 | ⬜ 해당없음 | 문서 변경 |
| 문서 동기화 | ✅ 완료 | CONTENT_ARCHITECTURE 현황 반영 |

Closes #42